### PR TITLE
Adding support for manipulation of DocumentFragments

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -266,6 +266,10 @@
   (nodes [content] (cons content))
   (single-node [content] content)
 
+  js/DocumentFragment
+  (nodes [content] (cons content))
+  (single-node [content] content)
+
   default
   (nodes [content] (seq content))
   (single-node [content] (first content)))


### PR DESCRIPTION
Currently domina doesn't support appending to a DocumentFragment or appending a DocumentFragment to existing nodes.  This is a common use case:

(def tmp (.createDocumentFragment js/document))
(append! tmp "&lt;div&gt;testing&lt;/div&gt;")
(append! (xpath "//body")  tmp)

I have test cases but they aren't formated into your framework yet will submit them in a few days.
