### PR TITLE
Add remove-attr! function

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -212,6 +212,13 @@
     (.setAttribute n (core/name name) (apply str value)))
   content)
 
+(defn remove-attr!
+  "Removes the specified HTML property for each node in the content. Name may be a string or keyword."
+  [content name]
+  (doseq [n (nodes content)]
+    (.removeAttribute n (core/name name)))
+  content)
+
 ;; We don't use the existing style/parseStyleAttributes because it camelcases everything.
 ;; This uses the same technique, however.
 (defn parse-style-attributes

--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -2,7 +2,7 @@
   (:use [domina :only [nodes single-node by-id by-class children clone append!
                        prepend! detach! destroy! destroy-children! insert! insert-before!
                        insert-after! swap-content! style attr set-style! set-attr! styles attrs
-                       set-styles! set-attrs! has-class? add-class! remove-class! classes
+                       remove-attr! set-styles! set-attrs! has-class? add-class! remove-class! classes
                        text set-text! value set-value! html set-html! set-data! get-data log-debug]]
         [domina.xpath :only [xpath]]
         [domina.css :only [sel]]
@@ -376,6 +376,21 @@
                (set-attr! (xpath "//div[2]") :width 42)
                (assert (= "42" (attr (xpath "//div[1]") "width")))
                (assert (= "42" (attr (xpath "//div[2]") "width")))))
+
+(add-test "can remove an html attribute from a single node"
+          #(do (reset)
+               (append! (xpath "//body") "<div width='42'>1</div><div width='42'>2</div>")
+               (remove-attr! (xpath "//div[1]") "width")
+               (remove-attr! (xpath "//div[2]") :width)
+               (assert (nil? (attr (xpath "//div[1]") "width")))
+               (assert (nil? (attr (xpath "//div[2]") "width")))))
+
+(add-test "can remove an html attribute from multiple nodes"
+          #(do (reset)
+               (append! (xpath "//body") "<div width='42'>1</div><div width='42'>2</div>")
+               (remove-attr! (xpath "//div") "width")
+               (assert (nil? (attr (xpath "//div[1]") "width")))
+               (assert (nil? (attr (xpath "//div[2]") "width")))))
 
 (add-test "can get multiple CSS styles from a single node."
           #(do (reset)


### PR DESCRIPTION
Removing an attribute is especially useful for attributes like
"disabled", where the only way to re-enable an element is to completely
remove the "disabled" attribute.

I'd love to see this get pulled into Domina. If you questions or concerns about this feature, or if you'd like to see the implementation or the tests handled differently, just let me know.
