### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -452,7 +452,7 @@
    (nil? list-thing) '()
    (dm/satisfies? ISeqable list-thing) (seq list-thing)
    (array-like? list-thing) (lazy-nodelist list-thing)
-   :default (cons list-thing)))
+   :default (seq [list-thing])))
 
 ;;;;;;;;;;;;;;;;;;; Protocol Implementations ;;;;;;;;;;;;;;;;;
 
@@ -471,7 +471,7 @@
      (nil? content) '()
      (dm/satisfies? ISeqable content) (seq content)
      (array-like? content) (lazy-nodelist content)
-     :default (cons content)))
+     :default (seq [content])))
   (single-node [content]
     (cond
      (nil? content) nil

--- a/src/cljs/domina/events.cljs
+++ b/src/cljs/domina/events.cljs
@@ -92,7 +92,7 @@
 
 (defn- ancestor-nodes
   "Returns a seq of a node and its ancestors, starting with the document root."
-  ([n] (ancestor-nodes n (cons n)))
+  ([n] (ancestor-nodes n [n]))
   ([n so-far]
      (if-let [parent (.-parentNode n)]
        (recur parent (cons parent so-far))


### PR DESCRIPTION
There are some warnings during compilation about usage of cons with one argument. This commit fixes them.
