### PR TITLE
Problem when passing results of domina/children to domina/detach!

### DIFF
--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -269,6 +269,14 @@
                  (append! (xpath "//div[@class='d1']") n)
                  (assert (= 3 (count (nodes (xpath "//div[@class='d1']/p"))))))))
 
+(add-test "detach child nodes"
+          #(do (reset)
+               (standard-fixture)
+               (let [parent (xpath "//div[@class='d1']")
+                     detached-children (detach! (children parent))]
+                 (assert (= 0 (count (nodes (xpath "//div[@class='d1']/p")))))
+                 (assert (= 3 (count detached-children))))))
+
 (add-test "clear a node's contents"
           #(do (reset)
                (standard-fixture)


### PR DESCRIPTION
This patch adds a failing test that demonstrates a problem encountered when you use `children` to obtain a `DomContent` and then pass that `DomContent` to `detach!`. The test _should_ remove all 3 child nodes. Instead, it only removes 2 of the child nodes.
