### PR TITLE
fix use of some undeclared Vars.

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -372,7 +372,7 @@
           (doseq [node (nodes content)]
             (events/removeAll node)
             (set! (. node -innerHTML) value))
-          (catch Exception e
+          (catch js/Error e
             (replace-children! content value))))
       (replace-children! content html-string))
     content))


### PR DESCRIPTION
Fixes use of undeclared Vars `tag-name`, `Exception` and `start-wrap`

compiling domina with cljsbuild still complains about the protocol functions:
`WARNING: Use of undeclared Var domina/nodes at line 98
WARNING: Use of undeclared Var domina/single-node at line 98`
but I don't know how to fix this given clojurescript's state of being ridiculously underdocumented.
