### PR TITLE
Make html-to-dom public

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -63,7 +63,8 @@
                                                   html)))
                  (.-firstChild div)))
 
-(defn- html-to-dom
+(defn html-to-dom
+  "takes an string of html and returns a NodeList of dom fragments"
   [html]
   (let [html (cstring/replace html re-xhtml-tag "<$1></$2>")
         tag-name (. (str (second (re-find re-tag-name html)))


### PR DESCRIPTION
In in enfocus I had the need to use html-to-dom outside the scope of a base node.  I was using goog library but wanted to move to using domina because of the table issues it has.   I wonder if all of the html-to-dom stuff should be moved to some utilities namespace so its not confused with the main api once its public.  
