### PR TITLE
upgraded to cljsbuild 0.2.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,10 +2,12 @@
   :description "A DOM manipulation library for ClojureScript inspired by JQuery"
   :source-path "src/clj"
   :dependencies [[org.clojure/clojure "1.4.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "0.0-1450"]
-                                  [org.clojure/google-closure-library "0.0-1376-2"]
-                                  [org.clojure/google-closure-library-third-party "0.0-1376-2"]]}}
-  :plugins [[lein-cljsbuild "0.2.9"]
+
+  ;; :profiles {:dev {:dependencies [[org.clojure/clojurescript "0.0-1552"]
+  ;;                                 [org.clojure/google-closure-library "0.0-2029"]
+  ;;                                 [org.clojure/google-closure-library-third-party "0.0-2029"]]}}
+
+  :plugins [[lein-cljsbuild "0.2.10"]
             [lein-clojars "0.9.0"]]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds [{:source-path "src/cljs"


### PR DESCRIPTION
Hi Luke,
I upgraded domina 1.0.2-SNAPSHOT by removing the explicit dev dependencies and upgrading cljsbuild to version 0.2.10 which already includes the lates clojurescript. The only problem that I experienced is the long delay in returning from `$ lein cljsbuild once` after the successful compilation. I was not able to shoot the problem.

My best

Mimmo
