### PR TITLE
Handle nil styles

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -256,10 +256,13 @@
   "Returns a map of the CSS styles/values. Assumes content will be a single node. Style names are returned as keywords."
   [content]
   (let [style (attr content "style")]
-    (if (string? style)
-      (parse-style-attributes style)
-      (if (. style -cssText)
-        (parse-style-attributes (. style -cssText))))))
+    (cond (string? style)
+            (parse-style-attributes style)
+          (nil? style)
+            {}
+          (. style -cssText)
+            (parse-style-attributes (. style -cssText))
+          :else {})))
 
 (defn attrs
   "Returns a map of the HTML attributes/values. Assumes content will be a single node. Attribute names are returned as keywords."

--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -422,6 +422,12 @@
                (assert (= {:color "red" :background-color "black"}
                           (styles (xpath "//div"))))))
 
+(add-test "can get blank CSS styles from a single node."
+          #(do (reset)
+               (append! (xpath "//body") "<div>1</div>")
+               (assert (= {}
+                          (styles (xpath "//div"))))))
+
 (add-test "can get multiple HTML attributes from a single node."
           #(do (reset)
                (append! (xpath "//body") "<div>1</div>")


### PR DESCRIPTION
Currently calling `(domina.styles node)` where `node` has no styles defined will result in an error:

```
TypeError: 'null' is not an object (evaluating 'style.cssText')
```

This patch handles the nil case.
