### PR TITLE
Stop propagation for non-GClosure dispatch! use

### DIFF
--- a/src/cljs/domina/events.cljs
+++ b/src/cljs/domina/events.cljs
@@ -108,12 +108,12 @@
   (let [ancestors (ancestor-nodes (domina/single-node source))]
     ;; Capture phase
     (doseq [n ancestors]
-      (when-not (.-propagationStopped n)
+      (when-not (.-propagationStopped_ evt)
         (set! (.-currentTarget evt) n)
         (events/fireListeners n (.-type evt) true evt)))
     ;; Bubble phase
     (doseq [n (reverse ancestors)]
-      (when-not (.-propagationStopped n)
+      (when-not (.-propagationStopped_ evt)
         (set! (.-currentTarget evt) n)
         (events/fireListeners n (.-type evt) false evt)))
     (.-returnValue_ evt)))

--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -698,6 +698,18 @@
               (simulate-click-event (sel "#mybutton"))
               (assert @clicked))))
 
+(add-test "can listen for a browser event and stop propagation"
+          (fn []
+            (reset)
+            (append! (xpath "//body") "<div id='mydiv'>Text</div>")
+            (append! (sel "#mydiv") "<div id='internal'>Inner Stuff</div>")
+            (let [clicked (atom false)]
+              (listen! (sel "#internal") :click (fn [e] (stop-propagation e)))
+              (listen! (sel "#mydiv") :click (fn [e] (reset! clicked true)))
+              ; using the same dispatch! a user would use
+              (dispatch! (single-node (sel "#internal")) :click {})
+              (assert (not @clicked)))))
+
 (add-test "can extract string keys from an event using keyword accessors"
           (fn []
             (reset)


### PR DESCRIPTION
The property ends with an underscore and is on goog.events.Event
rather than nodes themselves.

This was tripping us up when running tests that `dispatch!`ed events to Domina's content objects. It looks like the existing Domina tests didn't catch this because they mostly trigger events with a custom `simulate-click-event` function.
