### PR TITLE
Capture target when dispatch!ing events

### DIFF
--- a/src/cljs/domina/events.cljs
+++ b/src/cljs/domina/events.cljs
@@ -100,6 +100,7 @@
 (defn dispatch-browser!
   "Intended for internal/testing use only. Clients should prefer dispatch!. Dispatches an event as a simulated browser event from the given source node. Emulates capture/bubble behavior. Returns false if any handlers called prevent-default, otherwise true."
   [source evt]
+  (set! (.-target evt) (domina/single-node source))
   (let [ancestors (ancestor-nodes (domina/single-node source))]
     ;; Capture phase
     (doseq [n ancestors]

--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -775,6 +775,21 @@
               (dispatch! (sel "#mybutton") :foobar {:some "data"})
               (assert (= [button body] @actual-elements)))))
 
+(add-test "target is correct when capturing custom events"
+          (fn []
+            (reset)
+            (append! (xpath "//body")
+                     "<div><button id='mybutton'>Text</button></div>")
+            (let [actual-elements (atom [])
+                  body (domina/single-node (sel "body"))
+                  button (domina/single-node (sel "button"))]
+              (listen! (sel "body") :foobar #(swap! actual-elements conj
+                                                    (target %)))
+              (listen! (sel "button") :foobar #(swap! actual-elements conj
+                                                      (target %)))
+              (dispatch! (sel "#mybutton") :foobar {:some "data"})
+              (assert (= [button button] @actual-elements)))))
+
 (add-test "can stop event propagation in the capture phase."
           (fn []
             (reset)


### PR DESCRIPTION
I was debugging a failing test on my project involving `events/dispatch!` and noticed that `(events/target event)` was nil, but `(events/current-target event)` was the right thing. I think the event's `target` should be set up before firing any of the listeners so that they have both `current-target` and `target` available.
