### PR TITLE
fix clone redefinition warning

### DIFF
--- a/src/cljs/domina.cljs
+++ b/src/cljs/domina.cljs
@@ -10,6 +10,7 @@
             [cljs.core :as core]
             [clojure.string :as cstring]
             [domina.support :as support])
+  (:refer-clojure :exclude [clone])
   (:require-macros [domina.macros :as dm]))
 
 ;;;;;;;;;;;;;;;;;;; Parse HTML to DOM ;;


### PR DESCRIPTION
resolve compilation warning when using domina

`clone already refers to: /clone being replaced by: domina/clone`
