### PR TITLE
Fix single segment namespace

### DIFF
--- a/src/cljs/domina/core.cljs
+++ b/src/cljs/domina/core.cljs
@@ -1,4 +1,4 @@
-(ns domina
+(ns domina.core
   (:require
    [goog.dom :as dom]
             [goog.dom.xml :as xml]

--- a/src/cljs/domina/css.cljs
+++ b/src/cljs/domina/css.cljs
@@ -1,5 +1,5 @@
 (ns domina.css
-  (:require [domina :as domina]
+  (:require [domina.core :as domina]
             [goog.dom :as dom]
             [goog.dom.query :as query]))
 

--- a/src/cljs/domina/events.cljs
+++ b/src/cljs/domina/events.cljs
@@ -1,6 +1,6 @@
 
 (ns domina.events
-  (:require [domina :as domina]
+  (:require [domina.core :as domina]
             [goog.object :as gobj]
             [goog.events :as events]))
 

--- a/src/cljs/domina/xpath.cljs
+++ b/src/cljs/domina/xpath.cljs
@@ -1,5 +1,5 @@
 (ns domina.xpath
-  (:require [domina :as domina]
+  (:require [domina.core :as domina]
             [goog.dom :as dom]))
 
 ;; This file covers the same basic functionality as goog.dom.xml.

--- a/test/cljs/domina/test.cljs
+++ b/test/cljs/domina/test.cljs
@@ -1,5 +1,5 @@
 (ns domina.test
-  (:use [domina :only [nodes single-node by-id by-class children
+  (:use [domina.core :only [nodes single-node by-id by-class children
                        common-ancestor ancestor? clone append!
                        prepend! detach!  destroy!  destroy-children!
                        insert!  insert-before!  insert-after!


### PR DESCRIPTION
Move to multiple namespace to prevent following warning

> WARNING: domina is a single segment namespace at line 1 file:/Users/user/.m2/repository/domina/domina/1.0.3/domina-1.0.3.jar!/domina.cljs

Fixes #77

Signed-off-by: Yen-Chin Lee coldnew.tw@gmail.com
