### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ There are also `listen-once!` and `capture-once!` variants of `listen!` and `cap
 
 ### Custom Events
 
-In addition to native events dispatched by the browser, Domina allows you to create and dispatch arbitary events using the `dispatch!` function.
+In addition to native events dispatched by the browser, Domina allows you to create and dispatch arbitrary events using the `dispatch!` function.
 
 The `dispatch!` function takes an event target as a DomContent (assumed to be a single node), an event type, and an event map. Keys and values in the event map are merged in to the event object, and can be used to pass arbitrary data to event handlers.
 


### PR DESCRIPTION
@levand, I've corrected a typographical error in the documentation of the [domina](https://github.com/levand/domina) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
